### PR TITLE
AEA-3788-split-out-allure-reports-per-environment

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -2,24 +2,31 @@ name: Regression Tests
 on:
   workflow_dispatch:
     inputs:
-          tags:
-            description: 'Test scenario tags'
-            required: true
-            type: string
-            default: "@regression"
-          environment:
-            description: 'Environment to run tests against'
-            type: environment
-            required: true
-            default: "DEV"
-          id:
-            description: 'Unique run identifier (Do not change this)'
-            required: false
-            default: "Manually Triggered Run"
-          pull_request_id:
-            description: 'The ID of the pull request'
-            required: false
-            default: ""
+      tags:
+        description: 'Test scenario tags'
+        required: true
+        type: string
+        default: "@regression"
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
+        default: "DEV"
+      product:
+        description: 'The product we are testing'
+        type: choice
+        options:
+          - EPS-FHIR
+        required: true
+        default: "EPS-FHIR"
+      id:
+        description: 'Unique run identifier (Do not change this)'
+        required: false
+        default: "Manually Triggered Run"
+      pull_request_id:
+        description: 'The ID of the pull request'
+        required: false
+        default: ""
 
 jobs:
   regression_tests:
@@ -32,9 +39,14 @@ jobs:
           fetch-depth: 0  # This causes all history to be fetched, which is required for calculate-version to function
 
       - name: ${{github.event.inputs.id}}
+        env:
+          ID: ${{github.event.inputs.id}}
+          env: ${{ inputs.environment }}
+          product: ${{ inputs.product }}
+          pull_request_id: ${{ inputs.pull_request_id }}
         run: |
-          echo run identifier ${{ inputs.id }}
-          echo run identifier ${{ inputs.id }}  >> "$GITHUB_STEP_SUMMARY"
+          echo run identifier $ID-$product-$env-$pull_request_id
+          echo run identifier $ID-$product-$env-$pull_request_id  >> "$GITHUB_STEP_SUMMARY"
 
       # using git commit sha for version of action to ensure we have stable version
       - name: Install asdf
@@ -61,7 +73,7 @@ jobs:
           path: ./.venv/
           key: ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv- 
+            ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
 
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -71,11 +83,14 @@ jobs:
         id: tests
         continue-on-error: true
         env:
-          PULL_REQUEST_ID: ${{ inputs.pull_request_id }}
+          product: ${{ inputs.product }}
+          environment: ${{ inputs.environment }}
+          pull_request_id: ${{ inputs.pull_request_id }}
+          tags: ${{ inputs.tags }}
         run: |
-            export PULL_REQUEST_ID=$PULL_REQUEST_ID
-            echo Pull request ID = $PULL_REQUEST_ID
-            poetry run python ./runner.py --env ${{ inputs.environment }} --tags ${{ inputs.tags }}
+            export PULL_REQUEST_ID=$pull_request_id
+            echo Pull request ID = $pull_request_id
+            poetry run python ./runner.py --env=$environment --product=$product --tags=$tags
 
       - name: Upload Artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
@@ -98,17 +113,23 @@ jobs:
           path: allure-results
 
       - name: Commit results to GitHub Pages Repo
+        env:
+          product: ${{ inputs.product }}
+          environment: ${{ inputs.environment }}
+          pull_request_id: ${{ inputs.pull_request_id }}
         run: |
           DATE_TIME=`date +"%Y%m%d%H%M%S"`
-          git checkout -b regression-tests-$DATE_TIME
+
+          git checkout -b regression-tests-$DATE_TIME-$product-$environment-$pull_request_id
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add allure-results/*
-          git commit -m "regression-tests-$DATE_TIME"
-          git push --set-upstream origin regression-tests-$DATE_TIME
+          git commit -m "regression-tests-$DATE_TIME-$product-$environment-$pull_request_id"
+          git push --set-upstream origin regression-tests-$DATE_TIME-$product-$environment-$pull_request_id
 
       - name: Report failure on test failure
         if: steps.tests.outcome != 'success'
         run: |
           echo The regression tests step failed, this likely means there are test failures.
+          echo The report will be generated shortly
           exit 1

--- a/features/environment.py
+++ b/features/environment.py
@@ -11,12 +11,12 @@ SANDBOX_INT_BASE_URL = "Https://sandbox.api.service.nhs.uk/"
 REF_BASE_URL = "Https://ref.api.service.nhs.uk/"
 
 ENVS = {
-    "internal-dev": INTERNAL_DEV_BASE_URL,
-    "internal-qa": INTERNAL_QA_BASE_URL,
-    "int": INT_BASE_URL,
-    "ref": REF_BASE_URL,
-    "internal-dev-sandbox": SANDBOX_DEV_BASE_URL,
-    "sandbox": SANDBOX_INT_BASE_URL,
+    "INTERNAL-DEV": INTERNAL_DEV_BASE_URL,
+    "INTERNAL-QA": INTERNAL_QA_BASE_URL,
+    "INT": INT_BASE_URL,
+    "REF": REF_BASE_URL,
+    "INTERNAL-DEV-SANDBOX": SANDBOX_DEV_BASE_URL,
+    "SANDBOX": SANDBOX_INT_BASE_URL,
 }
 
 # This will need rework when the pack includes additional products to test
@@ -25,7 +25,7 @@ EPS_SUFFIX = "electronic-prescriptions"
 
 
 def before_all(context):
-    env = context.config.userdata["env"].lower()
+    env = context.config.userdata["env"].upper()
 
     context.fhir_base_url = select_base_url(env) + EPS_SUFFIX
     # This will need rework when the pack includes additional products to test
@@ -38,8 +38,14 @@ def before_all(context):
 
 
 def after_all(context):
-    return
     # Add anything you want to happen after all the tests have completed here
+    env = context.config.userdata["env"].upper()
+    product = context.config.userdata["product"].upper()
+    properties_dict = {"PRODUCT": product, "ENV": env, "PR_ID": PULL_REQUEST_ID}
+
+    file_path = "./allure-results/environment.properties"
+    write_properties_file(file_path, properties_dict)
+    return
 
 
 def setup_logging(level: int = logging.INFO):
@@ -67,3 +73,11 @@ def select_base_url(env):
         return ENVS[env]
     else:
         raise ValueError(f"Unknown environment or missing base URL for: {env} .")
+
+
+def write_properties_file(file_path, properties_dict):
+    if os.path.exists(file_path):
+        os.remove(file_path)
+    with open(file_path, "w") as file:
+        for key, value in properties_dict.items():
+            file.write(f"{key}={value}\n")

--- a/runner.py
+++ b/runner.py
@@ -11,6 +11,11 @@ if __name__ == "__main__":
         help="The environment the tests are going to run in.",
     )
     parser.add_argument(
+        "--product",
+        required=True,
+        help="The product under test",
+    )
+    parser.add_argument(
         "--tags",
         required=False,
         help="Tags to include or exclude. use ~tag_name to exclude tags",
@@ -19,11 +24,12 @@ if __name__ == "__main__":
 
     # Convert to behave commandline args
     tags = f" --tags {argument.tags} " if argument.tags else ""
+    PRODUCT = f" -D product={argument.product}"
     ENV = f" -D env={argument.env}"
 
     # complete command
     command = (
-        f"behave{ENV}"
+        f"behave{PRODUCT}{ENV}"
         f" -f behave_cucumber_formatter:PrettyCucumberJSONFormatter"
         f" -o reports/cucumber_json.json"
         f" -f allure_behave.formatter:AllureFormatter"


### PR DESCRIPTION
## Summary

- :sparkles: New Feature
- :warning: Potential issues that might be caused by this change

### Details

environment.properties file created after tests are run. This is used by the report generation to determine the report structure and provide information on the home page of the report
added more information to the output of various steps in the github workflow
Added product as a mandatory multiple-choice input to regression_tests.yml workflow defaulted to EPS-FHIR
