### PR TITLE
Fix: [AEA-4125] - regression test pack does not have correct environments setup causing sandbox to fail

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: make install
         run: |
-          export PATH="/home/runner/.asdf/installs/poetry/1.7.0/bin:$PATH"
+          export PATH="/home/runner/.asdf/installs/poetry/1.8.0/bin:$PATH"
           cp .tool-versions ~/
           make install
 

--- a/features/steps/api_steps.py
+++ b/features/steps/api_steps.py
@@ -17,7 +17,7 @@ from utils.nhs_number_generator import random_nhs_number_generator
 @given("I am an authorised {user}")
 @when("I am an authorised {user}")
 def i_am_an_authorised_user(context, user):
-    if "SANDBOX" in context.config.userdata["env"]:
+    if "sandbox" in context.config.userdata["env"].lower():
         return
     env = context.config.userdata["env"]
     context.user = user
@@ -50,7 +50,7 @@ def i_release_a_prescription(context):
 
 @then("the response indicates success")
 def indicate_successful_response(context):
-    if "SANDBOX" in context.config.userdata["env"]:
+    if "sandbox" in context.config.userdata["env"].lower():
         return
     assert_ok_status_code(context)
     json_response = json.loads(context.response.content)

--- a/methods/eps_fhir/api_methods.py
+++ b/methods/eps_fhir/api_methods.py
@@ -67,7 +67,7 @@ def prepare_prescription(context):
     url = f"{context.eps_fhir_base_url}/FHIR/R4/$prepare"
     context.prepare_body = _create_new_prepare_body(context)
     headers = get_default_headers()
-    if "SANDBOX" not in context.config.userdata["env"]:
+    if "sandbox" not in context.config.userdata["env"].lower():
         headers.update({"Authorization": f"Bearer {context.auth_token}"})
     headers.update({"Content-Type": "application/json"})
     response = post(
@@ -93,7 +93,7 @@ def create_signed_prescription(context):
     url = f"{context.eps_fhir_base_url}/FHIR/R4/$process-message#prescription-order"
     context.signed_body = _create_signed_body(context)
     headers = get_default_headers()
-    if "SANDBOX" not in context.config.userdata["env"]:
+    if "sandbox" not in context.config.userdata["env"].lower():
         headers.update({"Authorization": f"Bearer {context.auth_token}"})
     post(data=context.signed_body, url=url, context=context, headers=headers)
     the_expected_response_code_is_returned(context, 200)
@@ -114,7 +114,7 @@ def release_signed_prescription(context):
     url = f"{context.eps_fhir_base_url}/FHIR/R4/Task/$release"
     context.release_body = _create_release_body(context)
     headers = get_default_headers()
-    if "SANDBOX" not in context.config.userdata["env"]:
+    if "sandbox" not in context.config.userdata["env"].lower():
         headers.update({"Authorization": f"Bearer {context.auth_token}"})
     headers.update({"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]})
     post(data=context.release_body, url=url, context=context, headers=headers)


### PR DESCRIPTION
## Summary

**Remove items from this list if they are not relevant. Remove this line once this has been done**

- Routine Change

### Details

Changes to casing for environment names caused an issue when trying to trigger a run via CI. Now the code will automatically convert any values to lowercase before attempting to process them to prevent this from occurring again

## Pull Request Naming

Pull requests should be named using the following format:

```text
Tag: [AEA-NNNN] - Short description
```

Tag can be one of:

- `Fix` - for a bug fix. (Patch release)
- `Update` - either for a backwards-compatible enhancement or for a rule change that adds reported problems. (Patch release)
- `New` - implemented a new feature. (Minor release)
- `Breaking` - for a backwards-incompatible enhancement or feature. (Major release)
- `Docs` - changes to documentation only. (Patch release)
- `Build` - changes to build process only. (No release)
- `Upgrade` - for a dependency upgrade. (Patch release)
- `Chore` - for refactoring, adding tests, etc. (anything that isn't user-facing). (Patch release)

If the current release is x.y.z then
- a patch release increases z by 1
- a minor release increases y by 1
- a major release increases x by 1

Correct tagging is necessary for our automated versioning and release process ([Release](./RELEASE.md)).

The description of your pull request will be used as the commit message for the merge, and also be included in the changelog. Please ensure that your title is sufficiently descriptive.

### Rerunning Checks

If you need to rename your pull request, you can restart the checks by either:

- Closing and reopening the pull request
- pushing an empty commit 
  ```bash
  git commit --allow-empty -m 'trigger build'
  git push
  ```
- Amend your last commit and force push to the branch
  ```bash
  git commit --amend --no-edit
  git push --force
  ```

Rerunning the checks from within the pull request will not use the updated title.
