### PR TITLE
Fix: [AEA-0000] - Fix EPS Fhir URL logic

### DIFF
--- a/methods/api/eps_api_methods.py
+++ b/methods/api/eps_api_methods.py
@@ -19,7 +19,7 @@ def calculate_eps_fhir_base_url(context):
     product = context.config.userdata["product"].upper()
     global PRESCRIBING_BASE_URL
     global DISPENSING_BASE_URL
-    if product == "EPS-FHIR":
+    if product != "EPS-FHIR-DISPENSING" and product != "EPS-FHIR-PRESCRIBING":
         PRESCRIBING_BASE_URL = context.eps_fhir_base_url
         DISPENSING_BASE_URL = context.eps_fhir_base_url
     else:


### PR DESCRIPTION
## Summary

- Routine Change

### Details

reversed logic to only apply split endpoints when product is NOT "EPS-FHIR-DISPENSING" and "EPS-FHIR-PRESCRIBING"