### PR TITLE
New: [AEA-0000] - Redirect the user if they're not logged in

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,9 @@
             "timonwong.shellcheck",
             "github.vscode-github-actions",
             "ms-python.pylint",
-            "ms-python.black-formatter"
+            "ms-python.black-formatter",
+            "jimasp.behave-vsc",
+            "ms-playwright.playwright"
         ],
         "settings": {
           "python.defaultInterpreterPath": "/workspaces/electronic-prescription-service-api-regression-tests/venv/bin/python",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3.12
 repos:   
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
         name: Check for merge conflict strings

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ guard-%:
 		exit 1; \
 	fi
 
-install: install-python install-hooks install-node install-playwright
+install: install-python install-hooks install-node
 
 update: update-poetry update-node install
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ guard-%:
 		exit 1; \
 	fi
 
-install: install-python install-hooks install-node
+install: install-python install-hooks install-node install-playwright
 
 update: update-poetry update-node install
 
@@ -20,6 +20,11 @@ update-poetry:
 
 install-python:
 	poetry install
+
+install-playwright:
+	playwright install
+	playwright install-deps
+	playwright install --force chrome
 
 install-hooks: install-python
 	poetry run pre-commit install --install-hooks --overwrite

--- a/features/environment.py
+++ b/features/environment.py
@@ -68,6 +68,7 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 PULL_REQUEST_ID = os.getenv("PULL_REQUEST_ID")
 JWT_PRIVATE_KEY = os.getenv("JWT_PRIVATE_KEY")
 JWT_KID = os.getenv("JWT_KID")
+HEADLESS = os.getenv("HEADLESS", "True").lower() in ("true", "1", "yes")
 
 CPTS_UI_PREFIX = "cpt-ui"
 EPS_FHIR_SUFFIX = "electronic-prescriptions"
@@ -128,7 +129,9 @@ def before_all(context):
     if product == "CPTS-UI":
         global _page
         playwright = sync_playwright().start()
-        context.browser = playwright.chromium.launch(headless=True, channel="chrome")
+        context.browser = playwright.chromium.launch(
+            headless=HEADLESS, channel="chrome"
+        )
 
     eps_api_methods.calculate_eps_fhir_base_url(context)
     print("CPTS-UI: ", context.cpts_ui_base_url)

--- a/features/steps/cpts_ui/select_your_role_steps.py
+++ b/features/steps/cpts_ui/select_your_role_steps.py
@@ -9,6 +9,7 @@ from features.environment import MOCK_CIS2_LOGIN_ID
 @when("I go to the select your role page")
 def i_go_to_the_select_your_role_page(context):
     context.page.goto(context.cpts_ui_base_url + "site/selectyourrole.html")
+    context.page.wait_for_url("**/selectyourrole.html")
 
 
 @given("I am on the select your role page")
@@ -26,11 +27,12 @@ def verify_on_select_your_role_page(context):
 
 @given("I am logged in")
 def login(context):
-    context.page.goto(context.cpts_ui_base_url + "site/login")
+    # FIXME: This will need to be updated when the SPA is fixed! Remove the .html
+    context.page.goto(context.cpts_ui_base_url + "site/login.html")
     context.page.get_by_role("button", name="Log in with mock CIS2").click()
     context.page.get_by_label("Username").fill(MOCK_CIS2_LOGIN_ID)
     context.page.get_by_role("button", name="Sign In").click()
-    context.page.wait_for_url("**/login.html")
+    context.page.wait_for_url("**/selectyourrole.html")
 
 
 @then("I can see the summary container")

--- a/features/steps/cpts_ui/select_your_role_steps.py
+++ b/features/steps/cpts_ui/select_your_role_steps.py
@@ -25,11 +25,11 @@ def verify_on_select_your_role_page(context):
 
 @given("I am logged in")
 def login(context):
-    context.page.goto(context.cpts_ui_base_url + "site/auth_demo.html")
+    context.page.goto(context.cpts_ui_base_url + "site/login")
     context.page.get_by_role("button", name="Log in with mock CIS2").click()
     context.page.get_by_label("Username").fill("555073103100")
     context.page.get_by_role("button", name="Sign In").click()
-    context.page.wait_for_url("**/auth_demo.html")
+    context.page.wait_for_url("**/login.html")
 
 
 @then("I can see the summary container")


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

⚠️ **_DO NOT MERGE UNTIL #261 HAS BEEN MERGED - THIS IS A FORK OF THAT BRANCH!_** ⚠️

If the user is not logged in, we currently just let them sit with that. 

This updates the behaviour to instead trigger the login flow if the user session is not present, or becomes invalid (e.g. expires). There is some additional logic to handle mock auth. If the deployment is in one of the approved environments (currently, anything but `prod`), then the user is sent to a login page, which allows signing in with mock or PTL, and signing out. It also displays some debugging information, and the access tokens for people who want to use these elsewhere, e.g. Postman.