### PR TITLE
Chore: [AEA-4743] - Add regression tests for 404 page

### DIFF
--- a/features/cpts_ui/notfound.feature
+++ b/features/cpts_ui/notfound.feature
@@ -10,3 +10,8 @@ Feature: The site has a 404 not found page
         Given I am logged in as a user with multiple access roles
         When I navigate to a non-existent page
         Then I am on the Page Not Found page
+
+    @deployed_only
+    Scenario: The user sees a "Page not found" error page when they navigate to a url that is not under /site
+        When I navigate outside the react app route
+        Then I am on the Page Not Found page

--- a/features/cpts_ui/notfound.feature
+++ b/features/cpts_ui/notfound.feature
@@ -1,0 +1,12 @@
+@cpts_ui @not_found_page @regression @blocker @smoke @ui
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4743
+Feature: The site has a 404 not found page
+
+    Scenario: The user is redirected to login when they navigate to an unknown page while not logged in
+        When I navigate to a non-existent page
+        Then I am on the login page
+        
+    Scenario: The user sees a "Page not found" error page when they navigate to an unknown page while logged in
+        Given I am logged in as a user with multiple access roles
+        When I navigate to a non-existent page
+        Then I am on the Page Not Found page

--- a/features/environment.py
+++ b/features/environment.py
@@ -158,6 +158,9 @@ def before_scenario(context, scenario):
     if "skip-sandbox" in scenario.effective_tags and "sandbox" in environment:
         scenario.skip("Marked with @skip-sandbox")
         return
+    if "deployed_only" in scenario.effective_tags and environment == "localhost":
+        scenario.skip("Marked as only to run in deployed environments")
+        return
     product = context.config.userdata["product"].upper()
     if product == "CPTS-UI":
         global _playwright

--- a/features/steps/__init__.py
+++ b/features/steps/__init__.py
@@ -7,3 +7,4 @@ from cpts_ui.rbac_banner import *  # noqa: F403,F401
 from cpts_ui.search_for_a_prescription_steps import *  # noqa: F403,F401
 from cpts_ui.select_your_role_steps import *  # noqa: F403,F401
 from cpts_ui.your_selected_role_steps import *  # noqa: F403,F401
+from cpts_ui.page_not_found_steps import *  # noqa: F403,F401

--- a/features/steps/cpts_ui/page_not_found_steps.py
+++ b/features/steps/cpts_ui/page_not_found_steps.py
@@ -10,6 +10,11 @@ def i_navigate_to_a_nonexistent_page(context):
     context.page.goto(context.cpts_ui_base_url + "site/spamandeggs")
 
 
+@when("I navigate outside the react app route")
+def i_navigate_to_a_non_app_page(context):
+    context.page.goto(context.cpts_ui_base_url + "spamandeggs")
+
+
 @then("I am on the Page Not Found page")
 def i_am_on_page_not_found(context):
     page = PageNotFound(context.page)

--- a/features/steps/cpts_ui/page_not_found_steps.py
+++ b/features/steps/cpts_ui/page_not_found_steps.py
@@ -1,0 +1,20 @@
+# pylint: disable=no-name-in-module
+from behave import when, then  # pyright: ignore [reportAttributeAccessIssue]
+from playwright.sync_api import expect
+
+from pages.page_not_found import PageNotFound
+
+
+@when("I navigate to a non-existent page")
+def i_navigate_to_a_nonexistent_page(context):
+    context.page.goto(context.cpts_ui_base_url + "site/spamandeggs")
+
+
+@then("I am on the Page Not Found page")
+def i_am_on_page_not_found(context):
+    page = PageNotFound(context.page)
+
+    expect(page.header_text).to_be_visible()
+    expect(page.body1).to_be_visible()
+    expect(page.body2).to_be_visible()
+    expect(page.body3).to_be_visible()

--- a/pages/page_not_found.py
+++ b/pages/page_not_found.py
@@ -1,0 +1,11 @@
+from playwright.sync_api import Page
+
+
+class PageNotFound:
+    def __init__(self, page: Page):
+        self.page = page
+
+        self.header_text = page.get_by_test_id("eps-404-header")
+        self.body1 = page.get_by_test_id("eps-404-body1")
+        self.body2 = page.get_by_test_id("eps-404-body2")
+        self.body3 = page.get_by_test_id("eps-404-body3")


### PR DESCRIPTION
## Summary

- Routine Change

### Details

404 page should have behaviour:
- if we aren't logged in, redirect to login
- if we are logged in, show an error page with a link to the search for prescription page