### PR TITLE
Fix: [AEA-4896] - add metadata tests for fhir facade apis

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -326,7 +326,7 @@ def after_all(context):
         if os.path.exists(directory_path) and os.path.isdir(directory_path):
             print(f"Directory '{directory_path}' exists. Deleting...")
             shutil.rmtree(directory_path)
-        if _page:
+        if "_page" in vars() or "_page" in globals():
             _page.close()
 
 

--- a/features/eps_fhir/metadata.feature
+++ b/features/eps_fhir/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised "api user" with EPS-FHIR app
+    Given I am an authorised api user with EPS-FHIR app
     When I make a request to the "eps_fhir" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir/metadata.feature
+++ b/features/eps_fhir/metadata.feature
@@ -1,4 +1,4 @@
-@eps_fhir_dispensing @regression @blocker @smoke
+@eps_fhir @regression @blocker @smoke
 @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
 Feature: I can retrieve metadata
 

--- a/features/eps_fhir/metadata.feature
+++ b/features/eps_fhir/metadata.feature
@@ -1,0 +1,9 @@
+@eps_fhir_dispensing @regression @blocker @smoke
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
+Feature: I can retrieve metadata
+
+  @metadata
+  Scenario: I can retrieve metadata specification
+    Given I am an authorised prescriber with EPS-FHIR app
+    When I make a request to the "eps_fhir" metadata endpoint
+    Then the response indicates a success

--- a/features/eps_fhir/metadata.feature
+++ b/features/eps_fhir/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised prescriber with EPS-FHIR app
+    Given I am an authorised "api user" with EPS-FHIR app
     When I make a request to the "eps_fhir" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir/validator.feature
+++ b/features/eps_fhir/validator.feature
@@ -29,30 +29,35 @@ Feature: I can call the validator endpoint
     And the validator response has many error issue
     And the validator response has error with diagnostic containing Failed to parse JSON encoded FHIR content
 
+  @skip
   Scenario: I can call the validator endpoint with missing dosage instructions message
     Given I am an authorised prescriber with EPS-FHIR app
     When I make a request with file missing_dosage_instructions/request.json to the eps_fhir validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dosage_instructions/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing dispense request quantity message
     Given I am an authorised prescriber with EPS-FHIR app
     When I make a request with file missing_dispense_request_quantity/request.json to the eps_fhir validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dispense_request_quantity/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing medication message
     Given I am an authorised prescriber with EPS-FHIR app
     When I make a request with file missing_medication/request.json to the eps_fhir validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_medication/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with too many medication requests message
     Given I am an authorised prescriber with EPS-FHIR app
     When I make a request with file too_many_medication_requests/request.json to the eps_fhir validator endpoint
     Then the response indicates a bad request
     And the validator response matches too_many_medication_requests/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with unknown endorsement message
     Given I am an authorised prescriber with EPS-FHIR app
     When I make a request with file unknown_endorsement/request.json to the eps_fhir validator endpoint

--- a/features/eps_fhir_dispensing/metadata.feature
+++ b/features/eps_fhir_dispensing/metadata.feature
@@ -1,0 +1,9 @@
+@eps_fhir_dispensing @regression @blocker @smoke
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
+Feature: I can retrieve metadata
+
+  @metadata
+  Scenario: I can retrieve metadata specification
+    Given I am an authorised dispenser with EPS-FHIR-DISPENSING app
+    When I make a request to the "eps_fhir_dispensing" metadata endpoint
+    Then the response indicates a success

--- a/features/eps_fhir_dispensing/metadata.feature
+++ b/features/eps_fhir_dispensing/metadata.feature
@@ -1,4 +1,4 @@
-@eps_fhir_dispensing @regression @blocker @smoke
+@eps_fhir_prescribing @regression @blocker @smoke
 @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
 Feature: I can retrieve metadata
 

--- a/features/eps_fhir_dispensing/metadata.feature
+++ b/features/eps_fhir_dispensing/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
+    Given I am an authorised api user with EPS-FHIR-DISPENSING app
     When I make a request to the "eps_fhir_dispensing" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir_dispensing/metadata.feature
+++ b/features/eps_fhir_dispensing/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised dispenser with EPS-FHIR-DISPENSING app
+    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
     When I make a request to the "eps_fhir_dispensing" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir_dispensing/metadata.feature
+++ b/features/eps_fhir_dispensing/metadata.feature
@@ -1,4 +1,4 @@
-@eps_fhir_prescribing @regression @blocker @smoke
+@eps_fhir_dispensing @regression @blocker @smoke
 @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
 Feature: I can retrieve metadata
 

--- a/features/eps_fhir_dispensing/unauthorised.feature
+++ b/features/eps_fhir_dispensing/unauthorised.feature
@@ -1,0 +1,17 @@
+@eps_fhir_prescribing @smoke @regression @blocker @create
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4432
+Feature: I can not call api when unauthorised
+
+  @skip-sandbox
+  Scenario: I can not call prepare endpoint when using api key
+    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
+    When I try to prepare a nominated prescription
+    Then the response indicates unauthorised
+
+  @skip-sandbox
+  Scenario: I can not call release endpoint when using api key
+    Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
+    And I successfully prepare and sign a nominated prescription
+    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
+    When I try to release then prescription
+    Then the response indicates unauthorised

--- a/features/eps_fhir_dispensing/unauthorised.feature
+++ b/features/eps_fhir_dispensing/unauthorised.feature
@@ -1,4 +1,4 @@
-@eps_fhir_prescribing @smoke @regression @blocker @create
+@eps_fhir_dispensing @smoke @regression @blocker @create
 @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4432
 Feature: I can not call api when unauthorised
 

--- a/features/eps_fhir_dispensing/unauthorised.feature
+++ b/features/eps_fhir_dispensing/unauthorised.feature
@@ -4,7 +4,7 @@ Feature: I can not call api when unauthorised
 
   @skip-sandbox
   Scenario: I can not call prepare endpoint when using api key
-    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
+    Given I am an authorised api user with EPS-FHIR-DISPENSING app
     When I try to prepare a nominated prescription
     Then the response indicates unauthorised
 
@@ -12,6 +12,6 @@ Feature: I can not call api when unauthorised
   Scenario: I can not call release endpoint when using api key
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     And I successfully prepare and sign a nominated prescription
-    Given I am an authorised "api user" with EPS-FHIR-DISPENSING app
-    When I try to release then prescription
+    Given I am an authorised api user with EPS-FHIR-DISPENSING app
+    When I try to release the prescription
     Then the response indicates unauthorised

--- a/features/eps_fhir_dispensing/validator.feature
+++ b/features/eps_fhir_dispensing/validator.feature
@@ -29,30 +29,35 @@ Feature: I can call the validator endpoint
     And the validator response has many error issue
     And the validator response has error with diagnostic containing Failed to parse JSON encoded FHIR content
 
+  @skip
   Scenario: I can call the validator endpoint with missing dosage instructions message
     Given I am an authorised prescriber with EPS-FHIR-DISPENSING app
     When I make a request with file missing_dosage_instructions/request.json to the eps_fhir_dispensing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dosage_instructions/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing dispense request quantity message
     Given I am an authorised prescriber with EPS-FHIR-DISPENSING app
     When I make a request with file missing_dispense_request_quantity/request.json to the eps_fhir_dispensing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dispense_request_quantity/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing medication message
     Given I am an authorised prescriber with EPS-FHIR-DISPENSING app
     When I make a request with file missing_medication/request.json to the eps_fhir_dispensing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_medication/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with too many medication requests message
     Given I am an authorised prescriber with EPS-FHIR-DISPENSING app
     When I make a request with file too_many_medication_requests/request.json to the eps_fhir_dispensing validator endpoint
     Then the response indicates a bad request
     And the validator response matches too_many_medication_requests/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with unknown endorsement message
     Given I am an authorised prescriber with EPS-FHIR-DISPENSING app
     When I make a request with file unknown_endorsement/request.json to the eps_fhir_dispensing validator endpoint

--- a/features/eps_fhir_prescribing/metadata.feature
+++ b/features/eps_fhir_prescribing/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised prescriber with EPS-FHIR-PRESCRIBER app
+    Given I am an authorised "api user" with EPS-FHIR-PRESCRIBER app
     When I make a request to the "eps_fhir_prescribing" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir_prescribing/metadata.feature
+++ b/features/eps_fhir_prescribing/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised "api user" with EPS-FHIR-PRESCRIBER app
+    Given I am an authorised api user with EPS-FHIR-PRESCRIBER app
     When I make a request to the "eps_fhir_prescribing" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir_prescribing/metadata.feature
+++ b/features/eps_fhir_prescribing/metadata.feature
@@ -1,4 +1,4 @@
-@eps_fhir_dispensing @regression @blocker @smoke
+@eps_fhir_prescribing @regression @blocker @smoke
 @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
 Feature: I can retrieve metadata
 

--- a/features/eps_fhir_prescribing/metadata.feature
+++ b/features/eps_fhir_prescribing/metadata.feature
@@ -4,6 +4,6 @@ Feature: I can retrieve metadata
 
   @metadata
   Scenario: I can retrieve metadata specification
-    Given I am an authorised api user with EPS-FHIR-PRESCRIBER app
+    Given I am an authorised api user with EPS-FHIR-PRESCRIBING app
     When I make a request to the "eps_fhir_prescribing" metadata endpoint
     Then the response indicates a success

--- a/features/eps_fhir_prescribing/metadata.feature
+++ b/features/eps_fhir_prescribing/metadata.feature
@@ -1,0 +1,9 @@
+@eps_fhir_dispensing @regression @blocker @smoke
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4896
+Feature: I can retrieve metadata
+
+  @metadata
+  Scenario: I can retrieve metadata specification
+    Given I am an authorised prescriber with EPS-FHIR-PRESCRIBER app
+    When I make a request to the "eps_fhir_prescribing" metadata endpoint
+    Then the response indicates a success

--- a/features/eps_fhir_prescribing/unauthorised.feature
+++ b/features/eps_fhir_prescribing/unauthorised.feature
@@ -1,0 +1,9 @@
+@eps_fhir_prescribing @smoke @regression @blocker @create
+@allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4432
+Feature: I can not call api when unauthorised
+
+  @skip-sandbox
+  Scenario: I can not call prepare endpoint when using api key
+    Given I am an authorised "api user" with EPS-FHIR-PRESCRIBING app
+    When I try to prepare a nominated prescription
+    Then the response indicates unauthorised

--- a/features/eps_fhir_prescribing/unauthorised.feature
+++ b/features/eps_fhir_prescribing/unauthorised.feature
@@ -4,6 +4,6 @@ Feature: I can not call api when unauthorised
 
   @skip-sandbox
   Scenario: I can not call prepare endpoint when using api key
-    Given I am an authorised "api user" with EPS-FHIR-PRESCRIBING app
+    Given I am an authorised api user with EPS-FHIR-PRESCRIBING app
     When I try to prepare a nominated prescription
     Then the response indicates unauthorised

--- a/features/eps_fhir_prescribing/validator.feature
+++ b/features/eps_fhir_prescribing/validator.feature
@@ -29,30 +29,35 @@ Feature: I can call the validator endpoint
     And the validator response has many error issue
     And the validator response has error with diagnostic containing Failed to parse JSON encoded FHIR content
 
+  @skip
   Scenario: I can call the validator endpoint with missing dosage instructions message
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     When I make a request with file missing_dosage_instructions/request.json to the eps_fhir_prescribing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dosage_instructions/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing dispense request quantity message
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     When I make a request with file missing_dispense_request_quantity/request.json to the eps_fhir_prescribing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_dispense_request_quantity/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with missing medication message
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     When I make a request with file missing_medication/request.json to the eps_fhir_prescribing validator endpoint
     Then the response indicates a bad request
     And the validator response matches missing_medication/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with too many medication requests message
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     When I make a request with file too_many_medication_requests/request.json to the eps_fhir_prescribing validator endpoint
     Then the response indicates a bad request
     And the validator response matches too_many_medication_requests/response.json
 
+  @skip
   Scenario: I can call the validator endpoint with unknown endorsement message
     Given I am an authorised prescriber with EPS-FHIR-PRESCRIBING app
     When I make a request with file unknown_endorsement/request.json to the eps_fhir_prescribing validator endpoint

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -51,6 +51,13 @@ def indicate_successful_response(context):
     common.the_expected_response_code_is_returned(context, 200)
 
 
+@then("the response indicates unauthorised")
+def indicate_unauthorised_response(context):
+    if "sandbox" in context.config.userdata["env"].lower():
+        return
+    common.the_expected_response_code_is_returned(context, 401)
+
+
 @then("the response indicates a record was created")
 def indicate_record_created(context):
     common.the_expected_response_code_is_returned(context, 201)

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -2,6 +2,7 @@
 from behave import when, then  # pyright: ignore [reportAttributeAccessIssue]
 from methods.shared import common
 from methods.api.common_api_methods import request_ping
+from methods.api.common_api_methods import request_metadata
 from methods.shared.common import assert_that
 
 
@@ -20,6 +21,25 @@ def i_make_a_request_to_the_ping_endpoint(context, product):
         base_url = context.cpts_api_base_url
     if base_url is not None:
         request_ping(context, base_url)
+    else:
+        raise ValueError(f"unable to find base url for '{product}'")
+
+
+@when('I make a request to the "{product}" metadata endpoint')
+def i_make_a_request_to_the_metadata_endpoint(context, product):
+    base_url = None
+    if product == "pfp":
+        base_url = context.pfp_base_url
+    if product == "eps_fhir":
+        base_url = context.eps_fhir_base_url
+    if product == "eps_fhir_prescribing":
+        base_url = context.eps_fhir_prescribing_base_url
+    if product == "eps_fhir_dispensing":
+        base_url = context.eps_fhir_dispensing_base_url
+    if product == "cpts_api":
+        base_url = context.cpts_api_base_url
+    if base_url is not None:
+        request_metadata(context, base_url)
     else:
         raise ValueError(f"unable to find base url for '{product}'")
 

--- a/features/steps/eps_api_steps.py
+++ b/features/steps/eps_api_steps.py
@@ -73,9 +73,7 @@ def i_am_an_authorised_user(context, user, app):
     if "sandbox" in context.config.userdata["env"].lower():
         return
     env = context.config.userdata["env"]
-    print("foo")
     print(user)
-    print("bar")
     if user == "api user":
         context.api_key = APIGEE_APPS[app]["client_id"]
         context.auth_method = "api_key"

--- a/features/steps/eps_api_steps.py
+++ b/features/steps/eps_api_steps.py
@@ -73,6 +73,9 @@ def i_am_an_authorised_user(context, user, app):
     if "sandbox" in context.config.userdata["env"].lower():
         return
     env = context.config.userdata["env"]
+    print("foo")
+    print(user)
+    print("bar")
     if user == "api user":
         context.api_key = APIGEE_APPS[app]["client_id"]
         context.auth_method = "api_key"

--- a/features/steps/eps_api_steps.py
+++ b/features/steps/eps_api_steps.py
@@ -109,8 +109,8 @@ def i_sign_a_new_prescription(context):
     create_signed_prescription(context)
 
 
+@when("I try to release the prescription")
 @when("I release the prescription")
-@given("I try to release the prescription")
 def i_release_the_prescription(context):
     release_signed_prescription(context)
 

--- a/features/steps/eps_api_steps.py
+++ b/features/steps/eps_api_steps.py
@@ -14,6 +14,7 @@ from methods.api.eps_api_methods import (
     withdraw_dispense_notification,
     call_validator,
 )
+from features.environment import APIGEE_APPS
 from methods.shared.common import assert_that, get_auth
 from utils.random_nhs_number_generator import generate_single
 from messages.eps_fhir.prescription import Prescription
@@ -73,6 +74,7 @@ def i_am_an_authorised_user(context, user, app):
     env = context.config.userdata["env"]
     context.user = user
     context.auth_token = get_auth(env, app, user)
+    context.api_key = APIGEE_APPS[app]["client_id"]
 
 
 @given("I successfully prepare a {prescription_type} prescription")

--- a/methods/api/common_api_methods.py
+++ b/methods/api/common_api_methods.py
@@ -29,16 +29,23 @@ def _get_default_headers():
     }
 
 
-def get_headers(context, additional_headers=None):
+def get_headers(context, auth_method, additional_headers=None):
     headers = _get_default_headers()
     if additional_headers:
         headers.update(additional_headers)
     if "sandbox" not in context.config.userdata["env"].lower():
-        try:
-            context.auth_token
-        except AttributeError:
-            return headers
-        headers["Authorization"] = f"Bearer {context.auth_token}"
+        if auth_method == "oauth2":
+            try:
+                context.auth_token
+            except AttributeError:
+                return headers
+            headers["Authorization"] = f"Bearer {context.auth_token}"
+        if auth_method == "api_key":
+            try:
+                context.api_key
+            except AttributeError:
+                return headers
+            headers["apikey"] = f"{context.api_key}"
     return headers
 
 
@@ -49,4 +56,4 @@ def request_ping(context, base_url):
 
 def request_metadata(context, base_url):
     url = f"{base_url}/metadata"
-    get(context=context, url=url, headers=_get_default_headers())
+    get(context=context, url=url, headers=get_headers(context, "api_key"))

--- a/methods/api/common_api_methods.py
+++ b/methods/api/common_api_methods.py
@@ -56,4 +56,4 @@ def request_ping(context, base_url):
 
 def request_metadata(context, base_url):
     url = f"{base_url}/metadata"
-    get(context=context, url=url, headers=get_headers(context, "api_key"))
+    get(context=context, url=url, headers=get_headers(context, context.auth_method))

--- a/methods/api/common_api_methods.py
+++ b/methods/api/common_api_methods.py
@@ -45,3 +45,8 @@ def get_headers(context, additional_headers=None):
 def request_ping(context, base_url):
     url = f"{base_url}/_ping"
     get(context=context, url=url, headers=_get_default_headers())
+
+
+def request_metadata(context, base_url):
+    url = f"{base_url}/metadata"
+    get(context=context, url=url, headers=_get_default_headers())

--- a/methods/api/eps_api_methods.py
+++ b/methods/api/eps_api_methods.py
@@ -30,7 +30,7 @@ def calculate_eps_fhir_base_url(context):
 def prepare_prescription(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$prepare"
     additional_headers = {"Content-Type": "application/json"}
-    headers = get_headers(context, "ouath2", additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.prepare_body = Prescription(context).body
     response = post(

--- a/methods/api/eps_api_methods.py
+++ b/methods/api/eps_api_methods.py
@@ -30,7 +30,7 @@ def calculate_eps_fhir_base_url(context):
 def prepare_prescription(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$prepare"
     additional_headers = {"Content-Type": "application/json"}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.prepare_body = Prescription(context).body
     response = post(
@@ -43,9 +43,18 @@ def prepare_prescription(context):
     context.algorithm = response.json()["parameter"][2]["valueString"]
 
 
+def try_prepare_prescription(context):
+    url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$prepare"
+    additional_headers = {"Content-Type": "application/json"}
+    headers = get_headers(context, context.auth_method, additional_headers)
+
+    context.prepare_body = Prescription(context).body
+    post(data=context.prepare_body, url=url, context=context, headers=headers)
+
+
 def create_signed_prescription(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$process-message#prescription-order"
-    headers = get_headers(context, "oauth2")
+    headers = get_headers(context, context.auth_method)
 
     context.signed_body = SignedPrescription(context).body
     post(data=context.signed_body, url=url, context=context, headers=headers)
@@ -55,7 +64,7 @@ def create_signed_prescription(context):
 def release_signed_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task/$release"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.release_body = Release(context).body
     post(data=context.release_body, url=url, context=context, headers=headers)
@@ -64,7 +73,7 @@ def release_signed_prescription(context):
 def cancel_all_line_items(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$process-message"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["prescriber"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.cancel_body = Cancel(context).body
     post(data=context.cancel_body, url=url, context=context, headers=headers)
@@ -73,7 +82,7 @@ def cancel_all_line_items(context):
 def dispense_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/$process-message#dispense-notification"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     dispense_notification = DispenseNotification(context, False).body
     post(data=dispense_notification, url=url, context=context, headers=headers)
@@ -82,7 +91,7 @@ def dispense_prescription(context):
 def amend_dispense_notification(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/$process-message#dispense-notification"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     amended_dispense_notification = DispenseNotification(context, True).body
     post(data=amended_dispense_notification, url=url, context=context, headers=headers)
@@ -91,7 +100,7 @@ def amend_dispense_notification(context):
 def withdraw_dispense_notification(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.dispense_notification_body = WithdrawDispenseNotification(context).body
 
@@ -106,7 +115,7 @@ def withdraw_dispense_notification(context):
 def return_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.return_body = Return(context).body
     post(data=context.return_body, url=url, context=context, headers=headers)
@@ -127,7 +136,7 @@ def call_validator(context, product, show_validation, validate_body):
         }
     else:
         additional_headers = {"Content-Type": "application/json"}
-    headers = get_headers(context, "oauth2", additional_headers)
+    headers = get_headers(context, context.auth_method, additional_headers)
 
     context.validate_body = validate_body
     post(data=context.validate_body, url=url, context=context, headers=headers)

--- a/methods/api/eps_api_methods.py
+++ b/methods/api/eps_api_methods.py
@@ -30,7 +30,7 @@ def calculate_eps_fhir_base_url(context):
 def prepare_prescription(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$prepare"
     additional_headers = {"Content-Type": "application/json"}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "ouath2", additional_headers)
 
     context.prepare_body = Prescription(context).body
     response = post(
@@ -45,7 +45,7 @@ def prepare_prescription(context):
 
 def create_signed_prescription(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$process-message#prescription-order"
-    headers = get_headers(context)
+    headers = get_headers(context, "oauth2")
 
     context.signed_body = SignedPrescription(context).body
     post(data=context.signed_body, url=url, context=context, headers=headers)
@@ -55,7 +55,7 @@ def create_signed_prescription(context):
 def release_signed_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task/$release"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.release_body = Release(context).body
     post(data=context.release_body, url=url, context=context, headers=headers)
@@ -64,7 +64,7 @@ def release_signed_prescription(context):
 def cancel_all_line_items(context):
     url = f"{PRESCRIBING_BASE_URL}/FHIR/R4/$process-message"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["prescriber"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.cancel_body = Cancel(context).body
     post(data=context.cancel_body, url=url, context=context, headers=headers)
@@ -73,7 +73,7 @@ def cancel_all_line_items(context):
 def dispense_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/$process-message#dispense-notification"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     dispense_notification = DispenseNotification(context, False).body
     post(data=dispense_notification, url=url, context=context, headers=headers)
@@ -82,7 +82,7 @@ def dispense_prescription(context):
 def amend_dispense_notification(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/$process-message#dispense-notification"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     amended_dispense_notification = DispenseNotification(context, True).body
     post(data=amended_dispense_notification, url=url, context=context, headers=headers)
@@ -91,7 +91,7 @@ def amend_dispense_notification(context):
 def withdraw_dispense_notification(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.dispense_notification_body = WithdrawDispenseNotification(context).body
 
@@ -106,7 +106,7 @@ def withdraw_dispense_notification(context):
 def return_prescription(context):
     url = f"{DISPENSING_BASE_URL}/FHIR/R4/Task"
     additional_headers = {"NHSD-Session-URID": CIS2_USERS["dispenser"]["role_id"]}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.return_body = Return(context).body
     post(data=context.return_body, url=url, context=context, headers=headers)
@@ -127,7 +127,7 @@ def call_validator(context, product, show_validation, validate_body):
         }
     else:
         additional_headers = {"Content-Type": "application/json"}
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
 
     context.validate_body = validate_body
     post(data=context.validate_body, url=url, context=context, headers=headers)

--- a/methods/api/pfp_api_methods.py
+++ b/methods/api/pfp_api_methods.py
@@ -8,5 +8,5 @@ def get_prescriptions(context):
         "nhsd-nhslogin-user": "P9:" + context.nhs_number,
     }
 
-    headers = get_headers(context, additional_headers)
+    headers = get_headers(context, "oauth2", additional_headers)
     context.response = get(url=url, context=context, headers=headers)

--- a/methods/api/psu_api_methods.py
+++ b/methods/api/psu_api_methods.py
@@ -5,7 +5,7 @@ from methods.api.common_api_methods import post, get_headers
 def send_status_update(context):
     url = f"{context.psu_base_url}/"
 
-    headers = get_headers(context)
+    headers = get_headers(context, "oauth2")
     context.send_update_body = StatusUpdate(context).body
     context.response = post(
         data=context.send_update_body, url=url, context=context, headers=headers


### PR DESCRIPTION
## Summary

- Routine Change

### Details
 - add metadata tests with api auth for fhir facade apis
 - skip validator tests for latest hapi-fhir
 - tests for api auth can not call other endpoints
 - add auth_method to get_headers