### PR TITLE
Fix: [AEA-0000] - Fix tests being wonky when run too fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ Make sure that your behave run configuration includes the `--product=` & `--env=
 Run the tests by calling the Make command `make run-tests`. This requires the parameters `product=` and `env=` to be passed in.
 Optionally, you can pass in tags to be run, for example `tags=cpt-ui` will run all CPT-UI-tagged tests.
 Further, if you want to actually see the tests being executed, you can pass a `HEADLESS=true` to the makefile.
+If you want to throttle the speed that the tests are done, you can insert a delay between each action by passing the `SLOWMO=<delay, ms>` environment variable. This lets a human keep track of what steps are being done.
 
 For example:
 ```
-product=cpts-ui env=internal-dev PULL_REQUEST_ID=pr-300 tags=cpt-ui HEADLESS=true make run-tests
+product=cpts-ui env=internal-dev PULL_REQUEST_ID=pr-300 tags=login HEADLESS=false SLOWMO=2000 make run-tests
 ```
 
 Note that CPT-UI supports localhost testing. To do this, use the `env=localhost` variable - but ensure you have *not* set the `PULL_REQUEST_ID` variable, as it is not needed and will break the tests. Make sure your localhost server is running!

--- a/features/cpts_ui/prescription_list.feature
+++ b/features/cpts_ui/prescription_list.feature
@@ -11,9 +11,11 @@ Feature: Prescription List Page in the Clinical Prescription Tracker Service
     And I can see the heading "Prescriptions list"
     And I can see the results count message
     
-  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4778  
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4778
+  @testme
   Scenario: Back link navigates to appropriate search tab when accessed from prescription ID search
     Given I am logged in as a user with a single access role
+    And I am on the search for a prescription page
     And I have accessed the prescription list page using a prescription ID search
     When I click on the "Go back" link
     Then I am redirected to the prescription ID search tab

--- a/features/environment.py
+++ b/features/environment.py
@@ -121,6 +121,7 @@ PULL_REQUEST_ID = os.getenv("PULL_REQUEST_ID")
 JWT_PRIVATE_KEY = os.getenv("JWT_PRIVATE_KEY")
 JWT_KID = os.getenv("JWT_KID")
 HEADLESS = os.getenv("HEADLESS", "True").lower() in ("true", "1", "yes")
+SLOWMO = float(os.getenv("SLOWMO", "0.0"))
 
 CPTS_UI_PREFIX = "cpt-ui"
 CPTS_FHIR_SUFFIX = "clinical-prescription-tracker"
@@ -239,7 +240,7 @@ def before_all(context):
         global _playwright
         _playwright = sync_playwright().start()
         context.browser = _playwright.chromium.launch(
-            headless=HEADLESS, channel="chrome"
+            headless=HEADLESS, channel="chrome", slow_mo=SLOWMO
         )
 
     eps_api_methods.calculate_eps_fhir_base_url(context)

--- a/features/steps/cpts_ui/login_steps.py
+++ b/features/steps/cpts_ui/login_steps.py
@@ -131,6 +131,8 @@ def the_login_is_finished(context):
         valid_urls = [
             f"{context.cpts_ui_base_url}site/select-role",
             f"{context.cpts_ui_base_url}site/select-role/",
+            f"{context.cpts_ui_base_url}site/search",
+            f"{context.cpts_ui_base_url}site/search/",
         ]
         return url in valid_urls
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

One of the tests ran fine when being run outside of headless, but fails in headless mode. This fixes that. Also adds a `SLOWMO` environment variable that allows us to insert a delay between actions.