### PR TITLE
Fix: [AEA-4778] - pathname renames

### DIFF
--- a/features/steps/cpts_ui/home_steps.py
+++ b/features/steps/cpts_ui/home_steps.py
@@ -13,9 +13,9 @@ def goto_page(context, page):
     if page == "home":
         target = ""
     elif page == "search for a prescription":
-        target = "search"
+        target = "search-by-prescription-id"
     elif page == "select your role":
-        target = "select-role"
+        target = "select-your-role"
 
     url = f"{context.cpts_ui_base_url}site/{target}"
     context.page.goto(url)

--- a/features/steps/cpts_ui/login_steps.py
+++ b/features/steps/cpts_ui/login_steps.py
@@ -129,10 +129,10 @@ def login_with_single_role(context):
 def the_login_is_finished(context):
     def logged_in_urls(url):
         valid_urls = [
-            f"{context.cpts_ui_base_url}site/select-role",
-            f"{context.cpts_ui_base_url}site/select-role/",
-            f"{context.cpts_ui_base_url}site/search",
-            f"{context.cpts_ui_base_url}site/search/",
+            f"{context.cpts_ui_base_url}site/select-your-role",
+            f"{context.cpts_ui_base_url}site/select-your-role/",
+            f"{context.cpts_ui_base_url}site/search-by-prescription-id",
+            f"{context.cpts_ui_base_url}site/search-by-prescription-id/",
         ]
         return url in valid_urls
 

--- a/features/steps/cpts_ui/prescription_list_steps.py
+++ b/features/steps/cpts_ui/prescription_list_steps.py
@@ -19,7 +19,7 @@ def access_list_page_via_prescription_id(context):
     # Navigate directly to the results page with a prescription ID parameter
     context.page.goto(
         context.cpts_ui_base_url
-        + "site/prescription-results?prescriptionId=C0C757-A83008-C2D93O"
+        + "site/prescription-list?prescriptionId=C0C757-A83008-C2D93O"
     )
 
     # Verify we're on the prescription list page using data-testid
@@ -31,7 +31,7 @@ def access_list_page_via_prescription_id(context):
 def access_list_page_via_nhs_number(context):
     # Navigate directly to the results page with an NHS number parameter
     context.page.goto(
-        context.cpts_ui_base_url + "site/prescription-results?nhsNumber=123456"
+        context.cpts_ui_base_url + "site/prescription-list?nhsNumber=123456"
     )
 
     # Verify we're on the prescription list page using data-testid
@@ -43,13 +43,13 @@ def access_list_page_via_nhs_number(context):
     'I am redirected to the prescription list page with prescription ID "{prescription_id}"'
 )
 def verify_prescription_list_page(context, prescription_id):
-    # Wait until the URL includes prescription-results
-    context.page.wait_for_url(lambda url: "site/prescription-results" in url)
+    # Wait until the URL includes prescription-list
+    context.page.wait_for_url(lambda url: "site/prescription-list" in url)
 
     current_url = context.page.url
     assert (
-        "site/prescription-results" in current_url
-    ), f"Expected URL to contain 'site/prescription-results', got: {current_url}"
+        "site/prescription-list" in current_url
+    ), f"Expected URL to contain 'site/prescription-list', got: {current_url}"
     assert (
         "prescriptionId=" in current_url
     ), f"Expected URL to contain 'prescriptionId=', got: {current_url}"
@@ -93,8 +93,8 @@ def verify_redirect_to_prescription_id_tab(context):
     # Use more relaxed URL checking
     current_url = context.page.url
     assert (
-        "site/search" in current_url
-    ), f"Expected URL to contain 'site/search', got: {current_url}"
+        "site/search-by-prescription-id" in current_url
+    ), f"Expected URL to contain 'site/search-by-prescription-id', got: {current_url}"
 
     # Use the POM to verify we're on the Prescription ID search tab
     search_page = SearchForAPrescription(context.page)
@@ -106,8 +106,8 @@ def verify_redirect_to_nhs_number_tab(context):
     # Use more relaxed URL checking
     current_url = context.page.url
     assert (
-        "site/search" in current_url
-    ), f"Expected URL to contain 'site/search', got: {current_url}"
+        "site/search-by-nhs-number" in current_url
+    ), f"Expected URL to contain 'site/search-by-nhs-number', got: {current_url}"
 
     # Use the POM to verify we're on the NHS number search tab
     search_page = SearchForAPrescription(context.page)

--- a/features/steps/cpts_ui/prescription_not_found_page_steps.py
+++ b/features/steps/cpts_ui/prescription_not_found_page_steps.py
@@ -13,7 +13,7 @@ def i_am_on_prescription_not_found_page(context, tab_name):
     expect(page.body1).to_be_visible()
     expect(page.back_link).to_be_visible()
 
-    url_target = "/site/search"
+    url_target = "/site/search-by-prescription-id"
     if tab_name:
         url_target += f"#{tab_name}"
 

--- a/features/steps/cpts_ui/prescription_not_found_page_steps.py
+++ b/features/steps/cpts_ui/prescription_not_found_page_steps.py
@@ -13,9 +13,15 @@ def i_am_on_prescription_not_found_page(context, tab_name):
     expect(page.body1).to_be_visible()
     expect(page.back_link).to_be_visible()
 
-    url_target = "/site/search-by-prescription-id"
-    if tab_name:
-        url_target += f"#{tab_name}"
+    # Map tab_name to the corresponding URL
+    url_map = {
+        "PrescriptionIdSearch": "/site/search-by-prescription-id",
+        "NhsNumberSearch": "/site/search-by-nhs-number",
+        "BasicDetailsSearch": "/site/search-by-basic-details",
+    }
+
+    # Get the appropriate URL based on tab_name or default to prescription-id search
+    url_target = url_map.get(tab_name, "/site/search-by-prescription-id")
 
     expect(page.back_link).to_have_attribute("href", url_target)
 

--- a/features/steps/cpts_ui/search_for_a_prescription_steps.py
+++ b/features/steps/cpts_ui/search_for_a_prescription_steps.py
@@ -83,7 +83,7 @@ def click_search_button(context):
 
 @then('I am redirected to the prescription results page for "{prescription_id}"')
 def redirected_to_results(context, prescription_id):
-    expected_url = f"/site/prescription-results?prescriptionId={prescription_id}"
+    expected_url = f"/site/prescription-list?prescriptionId={prescription_id}"
     context.page.wait_for_url(lambda url: expected_url in url)
 
 

--- a/pages/prescription_list_page.py
+++ b/pages/prescription_list_page.py
@@ -5,7 +5,7 @@ class PrescriptionListPage:
     def __init__(self, page: Page):
         page.wait_for_load_state()
         self.page = page
-        self.url = "/prescription-results"
+        self.url = "/prescription-list"
 
         # Locators for elements on the page with updated data-testid attributes
         self.heading = page.locator("[data-testid='prescription-list-heading']")


### PR DESCRIPTION
## Summary

- Routine Change
- :warning: Potential issues that might be caused by this change

### Details

Changes URL pathnames to Designer and BA approved pathnames:
```
/select-role - /select-your-role
/selected-role - /your-selected-role
/change-role - /change-your-role
/prescription-results - /prescriptions-list
/search#PrescriptionId - /search-by-prescription-id 
/search#NhsNumber - /search-by-nhs-number
/search#BasicDetails - /search-by-basic-details
```

