### PR TITLE
New: [AEA-5046] - added regression tests for incorrect info on page refresh

### DIFF
--- a/features/cpts_ui/change_role.feature
+++ b/features/cpts_ui/change_role.feature
@@ -84,6 +84,21 @@ Feature: Users are able to change their roles, if they have multiple roles with 
     Then I am on the change role page
     And I can see the role that has been pre selected
 
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-5046
+  Scenario: User refreshes the page and retains roles with access
+    Given I am logged in as a user with multiple access roles
+    And I have confirmed a role
+    And I am on the change your role page
+    And I click a change role role card
+    When I click the change link next to the role text
+    Then I am on the change role page
+    And I can see the role that has been pre selected  
+
+    When I refresh the page
+    Then I am on the change role page
+    And I can see the role that has been pre selected
+    And I do not see the change role page header link
+
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4974
   Scenario: User can see roles with access cards
     Given I am logged in with a single access role and multiple without access

--- a/features/cpts_ui/change_role.feature
+++ b/features/cpts_ui/change_role.feature
@@ -89,15 +89,10 @@ Feature: Users are able to change their roles, if they have multiple roles with 
     Given I am logged in as a user with multiple access roles
     And I have confirmed a role
     And I am on the change your role page
-    And I click a change role role card
-    When I click the change link next to the role text
-    Then I am on the change role page
-    And I can see the role that has been pre selected  
-
-    When I refresh the page
-    Then I am on the change role page
-    And I can see the role that has been pre selected
-    And I do not see the change role page header link
+    When I click a change role role card
+    And I click the change link next to the role text
+    And I refresh the page
+    Then I do not see the change role page header link
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4974
   Scenario: User can see roles with access cards

--- a/features/steps/cpts_ui/change_role_steps.py
+++ b/features/steps/cpts_ui/change_role_steps.py
@@ -73,6 +73,11 @@ def i_go_to_change_my_role(context):
     change_role_page.change_role_header.click()
 
 
+@when("I refresh the page")
+def I_refresh_the_page(context):
+    context.page.reload()
+
+
 ############################################################################
 # THEN STEPS
 ############################################################################
@@ -147,3 +152,10 @@ def i_see_the_change_role_page_no_role_with_access_warning_message(context):
     change_role_page = ChangeRole(context.page)
     expect(change_role_page.no_access_title).to_be_visible()
     expect(change_role_page.no_access_content).to_be_visible()
+
+
+@then("I do not see the change role page 'no role with access' message")
+def then_i_do_not_see_the_no_access_message(context):
+    change_role_page = ChangeRole(context.page)
+    expect(change_role_page.no_access_title).not_to_be_visible()
+    expect(change_role_page.no_access_content).not_to_be_visible()


### PR DESCRIPTION
## Summary

The /changerole page is showing the selected role in the roles with access list when using the changerole links within the UI. After refreshing the page the duplicate is removed from the roles with access list and shows the page as expected. 


- Routine Change

