### PR TITLE
New: [AEA-4802] - Site org information cards

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
             "github.vscode-github-actions",
             "ms-python.pylint",
             "ms-python.black-formatter",
-            "jimasp.behave-vsc"
+            "jimasp.behave-vsc",
+            "Gruntfuggly.todo-tree"
         ],
         "settings": {
           "python.defaultInterpreterPath": "/workspaces/electronic-prescription-service-api-regression-tests/venv/bin/python",

--- a/features/cpts_ui/prescription_detail.feature
+++ b/features/cpts_ui/prescription_detail.feature
@@ -1,0 +1,34 @@
+@cpts_ui @prescription_details @regression @ui
+Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
+
+  Background:
+    Given I am logged in as a user with a single access role
+    And I am on the search for a prescription page
+
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
+  Scenario: User sees all the organisation cards when they should
+    Given I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
+    Then The prescriber site card is visible
+    And The dispenser site card is visible
+    And The nominated dispenser site card is visible
+
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
+  Scenario: User sees only the prescriber organisation card when they should
+    Given I go to the prescription details for prescription ID "209E3D-A83008-327F9F"
+    Then The prescriber site card is visible
+    And The dispenser site card is not visible
+    And The nominated dispenser site card is not visible
+
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
+  Scenario: User sees only the prescriber and dispenser organisation cards when they should
+    Given I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
+    Then The prescriber site card is visible
+    And The dispenser site card is visible
+    And The nominated dispenser site card is not visible
+
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
+  Scenario: User sees the all the organisation cards when one of them is missing site data
+    Given I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
+    Then The prescriber site card is visible
+    And The dispenser site card is visible
+    And The nominated dispenser site card is visible

--- a/features/cpts_ui/prescription_detail.feature
+++ b/features/cpts_ui/prescription_detail.feature
@@ -7,6 +7,7 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees all the organisation cards when they should
+    # FIXME: Remove references to static data
     When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
     Then The prescriber site card is visible
     And The dispenser site card is visible
@@ -14,6 +15,7 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber organisation card when they should
+    # FIXME: Remove references to static data
     When I go to the prescription details for prescription ID "209E3D-A83008-327F9F"
     Then The prescriber site card is visible
     And The dispenser site card is not visible
@@ -21,6 +23,7 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber and dispenser organisation cards when they should
+    # FIXME: Remove references to static data
     When I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
     Then The prescriber site card is visible
     And The dispenser site card is visible
@@ -28,6 +31,7 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees the all the organisation cards when one of them is missing site data
+    # FIXME: Remove references to static data
     When I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
     Then The prescriber site card is visible
     And The dispenser site card is visible

--- a/features/cpts_ui/prescription_detail.feature
+++ b/features/cpts_ui/prescription_detail.feature
@@ -7,28 +7,28 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees all the organisation cards when they should
-    Given I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
+    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber organisation card when they should
-    Given I go to the prescription details for prescription ID "209E3D-A83008-327F9F"
+    When I go to the prescription details for prescription ID "209E3D-A83008-327F9F"
     Then The prescriber site card is visible
     And The dispenser site card is not visible
     And The nominated dispenser site card is not visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber and dispenser organisation cards when they should
-    Given I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
+    When I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is not visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees the all the organisation cards when one of them is missing site data
-    Given I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
+    When I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is visible

--- a/features/cpts_ui/prescription_information_banner.feature
+++ b/features/cpts_ui/prescription_information_banner.feature
@@ -21,9 +21,9 @@ Feature: The site displays the prescription information banner
 
   # This test uses static mock data. Update once real prescription API integration is in place.
   Scenario: The banner shows eRD type with repeat info and days supply
-    When I go to the prescription details page with prescription ID "EC5ACF-A83008-733FD3"
+    When I go to the prescription details page with prescription ID "209E3D-A83008-327F9F"
     Then The prescription information banner shows
-      | Prescription ID | EC5ACF-A83008-733FD3 |
+      | Prescription ID | 209E3D-A83008-327F9F |
       | Issue Date      | 22-Jan-2025          |
       | Status          | All items dispensed  |
       | Type            | eRD 2 of 6           |
@@ -37,5 +37,5 @@ Feature: The site displays the prescription information banner
 
   # This test uses static mock data. Update once real prescription API integration is in place.
   Scenario: The loading message is displayed when prescription data is being fetched
-    When I go to the prescription details page with prescription ID "EC5ACF-A83008-733FD3"
+    When I go to the prescription details page with prescription ID "209E3D-A83008-327F9F"
     Then The page shows the loading message "Loading full prescription"

--- a/features/cpts_ui/prescription_list.feature
+++ b/features/cpts_ui/prescription_list.feature
@@ -46,7 +46,6 @@ Feature: Prescription List Page in the Clinical Prescription Tracker Service
     Then I can see the future prescriptions results table
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4792
-  @testme
   Scenario: Display past prescriptions results table when clicking the past tab heading
     Given I am logged in as a user with a single access role
     # FIXME: This will need to be updated when the search pages are updated to use real data

--- a/features/steps/__init__.py
+++ b/features/steps/__init__.py
@@ -10,4 +10,5 @@ from cpts_ui.your_selected_role_steps import *  # noqa: F403,F401
 from cpts_ui.page_not_found_steps import *  # noqa: F403,F401
 from cpts_ui.patient_details_banner import *  # noqa: F403,F401
 from cpts_ui.prescription_list_steps import *  # noqa: F403,F401
+from cpts_ui.prescription_details_steps import *  # noqa: F403,F401
 from cpts_ui.prescription_not_found_page_steps import *  # noqa: F403,F401

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -1,0 +1,64 @@
+from behave import given, when, then  # pyright: ignore [reportAttributeAccessIssue]
+from playwright.sync_api import expect
+
+from pages.prescription_details import PrescriptionDetailsPage
+
+# FIXME: Remove references to the dev link when we can navigate properly to the prescription details
+from pages.prescription_list_page import PrescriptionListPage
+
+
+@given('I go to the prescription details for prescription ID "{prescription_id}"')
+def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
+    context.execute_steps(
+        f"""
+    When I search for a prescription using a valid prescription ID "{prescription_id}"
+    And I click through to the prescription details page
+    """
+    )
+
+
+# FIXME: THIS IS FOR DEVELOPMENT ONLY - DELETE IT WHEN WE HAVE A PROPER USER FLOW!!!
+@when("I click through to the prescription details page")
+def i_click_to_prescription_details_page(context):
+    page = PrescriptionListPage(context.page)
+    page.dev_link.click()
+
+    context.page.wait_for_load_state()
+
+
+@then("The prescriber site card is {visibility}")
+def the_prescriber_site_card_is_visible(context, visibility):
+    page = PrescriptionDetailsPage(context.page)
+
+    if visibility == "visible":
+        expect(page.prescriber_card).to_be_visible()
+        expect(page.prescribed_from_field).to_be_visible()
+    elif visibility == "not visible":
+        expect(page.prescriber_card).not_to_be_visible()
+        expect(page.prescribed_from_field).not_to_be_visible()
+    else:
+        raise ValueError(f"Unrecognised visibility definition: {visibility}")
+
+
+@then("The dispenser site card is {visibility}")
+def the_dispenser_site_card_is_visible(context, visibility):
+    page = PrescriptionDetailsPage(context.page)
+
+    if visibility == "visible":
+        expect(page.dispenser_card).to_be_visible()
+    elif visibility == "not visible":
+        expect(page.dispenser_card).not_to_be_visible()
+    else:
+        raise ValueError(f"Unrecognised visibility definition: {visibility}")
+
+
+@then("The nominated dispenser site card is {visibility}")
+def the_nominated_dispenser_site_card_is_visible(context, visibility):
+    page = PrescriptionDetailsPage(context.page)
+
+    if visibility == "visible":
+        expect(page.nominated_dispenser_card).to_be_visible()
+    elif visibility == "not visible":
+        expect(page.nominated_dispenser_card).not_to_be_visible()
+    else:
+        raise ValueError(f"Unrecognised visibility definition: {visibility}")

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -1,4 +1,4 @@
-from behave import given, when, then  # pyright: ignore [reportAttributeAccessIssue]
+from behave import when, then  # pyright: ignore [reportAttributeAccessIssue]
 from playwright.sync_api import expect
 
 from pages.prescription_details import PrescriptionDetailsPage
@@ -7,7 +7,7 @@ from pages.prescription_details import PrescriptionDetailsPage
 from pages.prescription_list_page import PrescriptionListPage
 
 
-@given('I go to the prescription details for prescription ID "{prescription_id}"')
+@when('I go to the prescription details for prescription ID "{prescription_id}"')
 def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
     context.execute_steps(
         f"""
@@ -26,39 +26,31 @@ def i_click_to_prescription_details_page(context):
     context.page.wait_for_load_state()
 
 
-@then("The prescriber site card is {visibility}")
-def the_prescriber_site_card_is_visible(context, visibility):
+@then("The {org} site card is {visibility}")
+def site_card_visibility_check(context, org, visibility):
     page = PrescriptionDetailsPage(context.page)
 
-    if visibility == "visible":
-        expect(page.prescriber_card).to_be_visible()
-        expect(page.prescribed_from_field).to_be_visible()
-    elif visibility == "not visible":
-        expect(page.prescriber_card).not_to_be_visible()
-        expect(page.prescribed_from_field).not_to_be_visible()
-    else:
-        raise ValueError(f"Unrecognised visibility definition: {visibility}")
-
-
-@then("The dispenser site card is {visibility}")
-def the_dispenser_site_card_is_visible(context, visibility):
-    page = PrescriptionDetailsPage(context.page)
+    expect_prescribed_from_field = False
+    match org:
+        case "prescriber":
+            card = page.prescriber_card
+            expect_prescribed_from_field = True
+        case "dispenser":
+            card = page.dispenser_card
+        case "nominated dispenser":
+            card = page.nominated_dispenser_card
+        case _:
+            raise ValueError(f"Unrecognised site definition: {org}")
 
     if visibility == "visible":
-        expect(page.dispenser_card).to_be_visible()
+        expect(card).to_be_visible()
+        if expect_prescribed_from_field:
+            expect(page.prescribed_from_field)
+
     elif visibility == "not visible":
-        expect(page.dispenser_card).not_to_be_visible()
-    else:
-        raise ValueError(f"Unrecognised visibility definition: {visibility}")
+        expect(card).not_to_be_visible()
+        if expect_prescribed_from_field:
+            expect(page.prescribed_from_field)
 
-
-@then("The nominated dispenser site card is {visibility}")
-def the_nominated_dispenser_site_card_is_visible(context, visibility):
-    page = PrescriptionDetailsPage(context.page)
-
-    if visibility == "visible":
-        expect(page.nominated_dispenser_card).to_be_visible()
-    elif visibility == "not visible":
-        expect(page.nominated_dispenser_card).not_to_be_visible()
     else:
         raise ValueError(f"Unrecognised visibility definition: {visibility}")

--- a/features/steps/cpts_ui/prescription_information_banner.py
+++ b/features/steps/cpts_ui/prescription_information_banner.py
@@ -60,8 +60,5 @@ def clipboard_has_text(context, expected):
 
 @then('The page shows the loading message "{expected_message}"')
 def check_loading_message(context, expected_message):
-    heading = context.page.locator("#prescription-details-page h2")
-    actual = heading.first.inner_text()
-    assert (
-        actual == expected_message
-    ), f"Expected heading '{expected_message}', but got '{actual}'"
+    heading = context.page.get_by_test_id("loading-message")
+    expect(heading).to_have_text(expected_message)

--- a/features/steps/cpts_ui/prescription_list_steps.py
+++ b/features/steps/cpts_ui/prescription_list_steps.py
@@ -18,6 +18,7 @@ def search_using_prescription_id(context, prescription_id):
 @given("I have accessed the prescription list page using a prescription ID search")
 def access_list_page_via_prescription_id(context):
     # Navigate directly to the results page with a prescription ID parameter
+    # FIXME: This should not be hardcoded once we can actually search for real data
     context.page.goto(
         context.cpts_ui_base_url
         + "site/prescription-list-current?prescriptionId=C0C757-A83008-C2D93O"

--- a/pages/prescription_details.py
+++ b/pages/prescription_details.py
@@ -1,0 +1,17 @@
+from playwright.sync_api import Page
+
+
+class PrescriptionDetailsPage:
+
+    def __init__(self, page: Page):
+        page.wait_for_load_state()
+        self.page = page
+        self.url = "/prescription-details"
+
+        # Site org cards
+        self.dispenser_card = page.get_by_test_id("site-card-dispenser")
+        self.nominated_dispenser_card = page.get_by_test_id(
+            "site-card-nominated-dispenser"
+        )
+        self.prescriber_card = page.get_by_test_id("site-card-prescriber")
+        self.prescribed_from_field = page.get_by_test_id("site-card-prescribed-from")

--- a/pages/prescription_list_page.py
+++ b/pages/prescription_list_page.py
@@ -7,6 +7,9 @@ class PrescriptionListPage:
         self.page = page
         self.url = "/prescription-list"
 
+        # FIXME: DELETEME
+        self.dev_link = page.get_by_test_id("prescription-details-link-container")
+
         # Locators for elements on the page with updated data-testid attributes
         self.heading = page.get_by_test_id("prescription-list-heading")
         self.results_count = page.get_by_test_id("results-count")


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Basic tests. Note that this is only creating the prescription details page so that the cards have somewhere to live - the actual surrounding page is way beyond the scope of this ticket, so ONLY the cards are checked for.

Also, since we have no live data yet, I've added a dev link to take us to the prescription details page. This will need to be removed later, and I've left a fixme note to that effect.