### PR TITLE
New: [AEA-5343] - Make tests use real data for prescription tracker

### DIFF
--- a/features/cpts_ui/prescription_detail.feature
+++ b/features/cpts_ui/prescription_detail.feature
@@ -7,95 +7,100 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees all the organisation cards when they should
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
+    Given a nominated acute prescription has been created and released
+    When I go to the prescription details
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber organisation card when they should
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "3DA34A-A83008-A0B2EV"
+    Given a non-nominated acute prescription has been created
+    When I go to the prescription details
     Then The prescriber site card is visible
     And The dispenser site card is not visible
     And The nominated dispenser site card is not visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees only the prescriber and dispenser organisation cards when they should
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
+    Given a non-nominated acute prescription has been created and released to FA565
+    When I go to the prescription details
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is not visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4802
   Scenario: User sees the all the organisation cards when one of them is missing site data
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
+    Given a nominated acute prescription has been created and released to INVALID
+    When I go to the prescription details
     Then The prescriber site card is visible
     And The dispenser site card is visible
     And The nominated dispenser site card is visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
+  @skip # can't make multi item prescriptions as it stands
   Scenario: User sees both prescribed and dispensed item cards
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
+    Given a new prescription has been dispensed
+    When I go to the prescription details
     Then The prescribed items card is visible
     And The dispensed items card is visible
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
   Scenario: User sees EPS status tag on item card
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
+    Given a nominated acute prescription has been created
+    When I go to the prescription details
     Then An item card shows an EPS status tag
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
   Scenario: User sees only prescribed items with cancellation warning
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
+    Given a nominated acute prescription has been created and released
+    And the prescription has been cancelled
+    When I go to the prescription details
     Then The prescribed items card is visible
     And The dispensed items card is not visible
     And A prescribed item card shows a cancellation warning
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
+  @skip # can't dispense a different item to the original prescription as it stands
   Scenario: User sees only dispensed item cards, with expandable and status tag
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "B8C9E2-A83008-5F7B3A"
+    Given a new prescription has been dispensed
+    When I go to the prescription details
     Then The prescribed items card is not visible
     And The dispensed items card is visible
     And A dispensed item card has expandable initial prescription
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
-    # FIXME: Remove references to static data
   Scenario: Dispensed item cards do not show pharmacy status when it is missing
-    When I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
+    Given a new prescription has been dispensed
+    When I go to the prescription details
     Then No pharmacy status label is shown in the dispensed item card
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4801
   Scenario: User sees message history with dispense notification dropdown
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "4D6F2C-A83008-A3E7D1"
+    Given a new prescription has been dispensed
+    When I go to the prescription details
     Then The message history timeline is visible
     And A dispense notification information dropdown is shown
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4801
   Scenario: User sees message history with pending cancellation
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "7F1A4B-A83008-91DC2E"
+    Given a nominated acute prescription has been created and released
+    And the prescription has been cancelled
+    When I go to the prescription details
     Then The message history timeline is visible
     And A pending cancellation message is shown
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4801
   Scenario: User sees message history for a cancelled prescription
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "3DA34A-A83008-A0B2EV"
+    Given a nominated acute prescription has been created
+    And the prescription has been cancelled
+    When I go to the prescription details
     Then The message history timeline is visible
     And A cancelled status message is shown
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4801
   Scenario: User sees fallback text for missing site names in message history
-    # FIXME: Remove references to static data
-    When I go to the prescription details for prescription ID "88AAF5-A83008-3D404Q"
+    Given a nominated acute prescription has been created and released to INVALID
+    When I go to the prescription details
     Then The message history timeline is visible
     And The timeline shows fallback text for missing site names

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -4,6 +4,14 @@ from playwright.sync_api import expect
 from pages.prescription_details import PrescriptionDetailsPage
 
 
+@when("I go to the prescription details")
+def i_go_to_prescription_details(context):
+    prescription_id = context.prescription_id
+    context.execute_steps(
+        f'I go to the prescription details for prescription ID "{prescription_id}"'
+    )
+
+
 @when('I go to the prescription details for prescription ID "{prescription_id}"')
 def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
     context.prescription_id = prescription_id

--- a/features/steps/eps_api_steps.py
+++ b/features/steps/eps_api_steps.py
@@ -59,27 +59,78 @@ def i_prepare_and_sign_a_type_prescription(context, nomination, prescription_typ
     i_sign_a_new_prescription(context=context)
 
 
+@given("a {nomination} {prescription_type} prescription has been created")
+def a_proxygen_prescription_has_been_created(context, nomination, prescription_type):
+    a_prescription_has_been_created(context, nomination, prescription_type, "proxygen")
+
+
 @given(
-    "a {nomination} {prescription_type} prescription has been created and released using {deployment_method} apis"
+    "a {nomination} {prescription_type} prescription has been created using {deployment_method} apis"
 )
-def a_prescription_has_been_created_and_released(
+def a_prescription_has_been_created(
     context, nomination, prescription_type, deployment_method
 ):
     if "sandbox" in context.config.userdata["env"].lower():
         return
     if deployment_method == "apim":
         prescribe_product = "EPS-FHIR"
-        dispense_product = "EPS-FHIR"
     elif deployment_method == "proxygen":
         prescribe_product = "EPS-FHIR-PRESCRIBING"
-        dispense_product = "EPS-FHIR-DISPENSING"
     else:
         raise ValueError(f"Unknown deployment_method {deployment_method}")
     i_am_an_authorised_user(context, "prescriber", prescribe_product)
     i_prepare_and_sign_a_type_prescription(context, nomination, prescription_type)
+
+
+@given("a {nomination} {prescription_type} prescription has been created and released")
+def a_proxygen_prescription_has_been_created_and_released(
+    context, nomination, prescription_type
+):
+    a_prescription_has_been_created_and_released(
+        context, nomination, prescription_type, "proxygen"
+    )
+
+
+@given(
+    "a {nomination} {prescription_type} prescription has been created and released to {receiver_ods_code}"
+)
+def a_proxygen_prescription_has_been_created_and_released_to(
+    context, nomination, prescription_type, receiver_ods_code
+):
+    a_prescription_has_been_created(context, nomination, prescription_type, "proxygen")
+    context.receiver_ods_code = receiver_ods_code
+    the_prescription_has_been_released(context, "proxygen")
+
+
+@given(
+    "a {nomination} {prescription_type} prescription has been created and released using {deployment_method} apis"
+)
+def a_prescription_has_been_created_and_released(
+    context, nomination, prescription_type, deployment_method
+):
+    a_prescription_has_been_created(
+        context, nomination, prescription_type, deployment_method
+    )
+    the_prescription_has_been_released(context, deployment_method)
+
+
+def the_prescription_has_been_released(context, deployment_method):
+    if "sandbox" in context.config.userdata["env"].lower():
+        return
+    if deployment_method == "apim":
+        dispense_product = "EPS-FHIR"
+    elif deployment_method == "proxygen":
+        dispense_product = "EPS-FHIR-DISPENSING"
+    else:
+        raise ValueError(f"Unknown deployment_method {deployment_method}")
     i_am_an_authorised_user(context, "dispenser", dispense_product)
     i_release_the_prescription(context)
     indicate_successful_response(context)
+
+
+@given("a new prescription has been dispensed")
+def a_proxygen_prescription_has_been_dispensed(context):
+    a_new_prescription_has_been_dispensed(context, "proxygen")
 
 
 @given("a new prescription has been dispensed using {deployment_method} apis")
@@ -91,6 +142,12 @@ def a_new_prescription_has_been_dispensed(context, deployment_method):
     )
     i_dispense_the_prescription(context)
     indicate_successful_response(context)
+
+
+@given("the prescription has been cancelled")
+def the_proxygen_prescription_has_been_cancelled(context):
+    i_am_an_authorised_user(context, "prescriber", "EPS-FHIR-PRESCRIBING")
+    i_cancel_all_line_items(context)
 
 
 @given("I am an authorised {user} with {app} app")


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

Removing hard coded values to match mock data in prescription tracker pages and setting up the data they need at the start of each test