### PR TITLE
Fix: [AEA-5480] - testing for not tab cycling when typing and using arrow keys

### DIFF
--- a/features/cpts_ui/search_for_a_prescription.feature
+++ b/features/cpts_ui/search_for_a_prescription.feature
@@ -25,6 +25,13 @@ Feature: I can visit the Clinical Prescription Tracker Service Website
       | NHS Number Search      |
       | Basic Details Search   |
 
+  @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-5480
+  Scenario: user pressing arrow keys when filling out a form cycles between the text rather than between tab headings
+    Given I am logged in as a user with a single access role
+    When I am on the search for a prescription page
+    And I enter text in an input box
+    Then I am not redirected to another tab
+
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4535
   @rbac_banner
   Scenario: User can see their RBAC banner when a role is selected

--- a/features/steps/cpts_ui/search_for_a_prescription_steps.py
+++ b/features/steps/cpts_ui/search_for_a_prescription_steps.py
@@ -51,6 +51,23 @@ def i_am_on_tab(context, tab_name):
             raise AssertionError(f"Unknown tab {tab_name}")
 
 
+@when("I enter text in an input box")
+def i_enter_text_in_input_box(context):
+    search_box = context.page.get_by_test_id("search-by-prescriptionid-box")
+    search_box.click()
+    search_box.fill("1234567890")
+    search_box.press("ArrowLeft")
+    search_box.press("ArrowRight")
+
+
+@then("I am not redirected to another tab")
+def i_am_not_redirected(context):
+    page = SearchForAPrescription(context.page)
+    expect(page.prescription_id_search_header).to_be_visible()
+    expect(page.nhs_number_search_header).to_be_visible(visible=False)
+    expect(page.basic_details_search_header).to_be_visible(visible=False)
+
+
 @then("I can see the search for a prescription header")
 def i_can_see_the_search_for_a_prescription_header(context):
     page = SearchForAPrescription(context.page)


### PR DESCRIPTION
## Summary

When the cursor is inside a text field, using the left/right arrow keys is changing tabs and removing the entered text. This should instead be moving through the text in the field 

- Routine Change
