### PR TITLE
Fix: [AEA-5492] - do not use direct url for search results

### DIFF
--- a/features/cpts_ui/prescription_detail.feature
+++ b/features/cpts_ui/prescription_detail.feature
@@ -72,13 +72,13 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4799
   Scenario: Dispensed item cards do not show pharmacy status when it is missing
     Given a new prescription has been dispensed
-    When I go to the prescription details
+    When I go to the past prescription details
     Then No pharmacy status label is shown in the dispensed item card
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4801
   Scenario: User sees message history with dispense notification dropdown
     Given a new prescription has been dispensed
-    When I go to the prescription details
+    When I go to the past prescription details
     Then The message history timeline is visible
     And A dispense notification information dropdown is shown
 
@@ -94,7 +94,7 @@ Feature: Prescription Detail Page in the Clinical Prescription Tracker Service
   Scenario: User sees message history for a cancelled prescription
     Given a nominated acute prescription has been created
     And the prescription has been cancelled
-    When I go to the prescription details
+    When I go to the past prescription details
     Then The message history timeline is visible
     And A cancelled status message is shown
 

--- a/features/cpts_ui/prescription_information_banner.feature
+++ b/features/cpts_ui/prescription_information_banner.feature
@@ -12,21 +12,21 @@ Feature: The site displays the prescription information banner
 
   @skip # FIXME: temporary until use of real data in tracker is fixed
   Scenario: When I view an Acute prescription, the banner appears
-    When I go to the prescription details page with prescription ID "C0C757-A83008-C2D93O"
+    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
     Then The prescription information banner is visible
 
   @skip # FIXME: temporary until use of real data in tracker is fixed
   Scenario: When I view an eRD prescription, the banner shows repeat and days supply
-    When I go to the prescription details page with prescription ID "3F885D-A83008-900ACJ"
+    When I go to the prescription details for prescription ID "3F885D-A83008-900ACJ"
     Then The prescription information banner displays repeat and days supply data
 
   @skip # FIXME: temporary until use of real data in tracker is fixed
   Scenario: The copy to clipboard button copies the ID
-    When I go to the prescription details page with prescription ID "C0C757-A83008-C2D93O"
+    When I go to the prescription details for prescription ID "C0C757-A83008-C2D93O"
     And I click the copy prescription ID button
     Then The clipboard contains "C0C757-A83008-C2D93O"
 
   @skip # FIXME: temporary until use of real data in tracker is fixed
   Scenario: The loading message is displayed when prescription data is being fetched
-    When I go to the prescription details page with prescription ID "209E3D-A83008-327F9F"
+    When I go to the prescription details for prescription ID "209E3D-A83008-327F9F"
     Then The page shows the loading message "Loading full prescription"

--- a/features/cpts_ui/search_for_a_prescription.feature
+++ b/features/cpts_ui/search_for_a_prescription.feature
@@ -73,6 +73,7 @@ Feature: I can visit the Clinical Prescription Tracker Service Website
 
   @allure.tms:https://nhsd-jira.digital.nhs.uk/browse/AEA-4783
   @find_prescription
+  @skip # this will not work as prescription is not in url 
   Scenario: User enters a valid prescription ID and is redirected to results page
     Given I am logged in as a user with a single access role
     When I click on tab Prescription ID search

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -12,11 +12,28 @@ def i_go_to_prescription_details(context):
     )
 
 
+@when("I go to the past prescription details")
+def i_go_to_past_prescription_details(context):
+    prescription_id = context.prescription_id
+    context.execute_steps(
+        f'When I go to the past prescription details for prescription ID "{prescription_id}"'
+    )
+
+
 @when('I go to the prescription details for prescription ID "{prescription_id}"')
 def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
     context.prescription_id = prescription_id
     context.execute_steps("Given I am on the search for a prescription page")
     context.execute_steps("When I search for the prescription by prescription ID")
+    context.execute_steps("When I click on the view prescription link")
+
+
+@when('I go to the past prescription details for prescription ID "{prescription_id}"')
+def i_go_to_past_prescription_details_for_prescription_id(context, prescription_id):
+    context.prescription_id = prescription_id
+    context.execute_steps("Given I am on the search for a prescription page")
+    context.execute_steps("When I search for the prescription by prescription ID")
+    context.execute_steps('When I click on the "past" prescriptions tab heading')
     context.execute_steps("When I click on the view prescription link")
 
 

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -2,39 +2,41 @@ from behave import when, then  # pyright: ignore [reportAttributeAccessIssue]
 from playwright.sync_api import expect
 
 from pages.prescription_details import PrescriptionDetailsPage
+from .search_for_a_prescription_steps import i_am_on_the_search_prescription_page
+from .prescription_list_steps import (
+    search_context_prescription_id,
+    click_view_prescriptions_link,
+    i_click_on_tab_heading,
+)
 
 
 @when("I go to the prescription details")
 def i_go_to_prescription_details(context):
     prescription_id = context.prescription_id
-    context.execute_steps(
-        f'When I go to the prescription details for prescription ID "{prescription_id}"'
-    )
+    i_go_to_prescription_details_for_prescription_id(context, prescription_id)
 
 
 @when("I go to the past prescription details")
 def i_go_to_past_prescription_details(context):
     prescription_id = context.prescription_id
-    context.execute_steps(
-        f'When I go to the past prescription details for prescription ID "{prescription_id}"'
-    )
+    i_go_to_past_prescription_details_for_prescription_id(context, prescription_id)
 
 
 @when('I go to the prescription details for prescription ID "{prescription_id}"')
 def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
     context.prescription_id = prescription_id
-    context.execute_steps("Given I am on the search for a prescription page")
-    context.execute_steps("When I search for the prescription by prescription ID")
-    context.execute_steps("When I click on the view prescription link")
+    i_am_on_the_search_prescription_page(context)
+    search_context_prescription_id(context)
+    click_view_prescriptions_link(context)
 
 
 @when('I go to the past prescription details for prescription ID "{prescription_id}"')
 def i_go_to_past_prescription_details_for_prescription_id(context, prescription_id):
     context.prescription_id = prescription_id
-    context.execute_steps("Given I am on the search for a prescription page")
-    context.execute_steps("When I search for the prescription by prescription ID")
-    context.execute_steps('When I click on the "past" prescriptions tab heading')
-    context.execute_steps("When I click on the view prescription link")
+    i_am_on_the_search_prescription_page(context)
+    search_context_prescription_id(context)
+    i_click_on_tab_heading(context, "past")
+    click_view_prescriptions_link(context)
 
 
 @then("The {org} site card is {visibility}")

--- a/features/steps/cpts_ui/prescription_details_steps.py
+++ b/features/steps/cpts_ui/prescription_details_steps.py
@@ -15,10 +15,9 @@ def i_go_to_prescription_details(context):
 @when('I go to the prescription details for prescription ID "{prescription_id}"')
 def i_go_to_prescription_details_for_prescription_id(context, prescription_id):
     context.prescription_id = prescription_id
-    context.page.goto(
-        context.cpts_ui_base_url
-        + f"site/prescription-details?prescriptionId={prescription_id}"
-    )
+    context.execute_steps("Given I am on the search for a prescription page")
+    context.execute_steps("When I search for the prescription by prescription ID")
+    context.execute_steps("When I click on the view prescription link")
 
 
 @then("The {org} site card is {visibility}")

--- a/features/steps/cpts_ui/prescription_information_banner.py
+++ b/features/steps/cpts_ui/prescription_information_banner.py
@@ -5,13 +5,6 @@ from playwright.sync_api import expect
 from pages.prescription_information_banner import PrescriptionInformationBanner
 
 
-@when('I go to the prescription details page with prescription ID "{prescription_id}"')
-def go_to_details_page(context, prescription_id):
-    context.page.goto(
-        f"{context.cpts_ui_base_url}site/prescription-details?prescriptionId={prescription_id}"
-    )
-
-
 @when("I go to the prescription details page without a prescription ID")
 def go_to_details_page_no_id(context):
     context.page.goto(f"{context.cpts_ui_base_url}site/prescription-details")

--- a/features/steps/cpts_ui/prescription_list_steps.py
+++ b/features/steps/cpts_ui/prescription_list_steps.py
@@ -269,7 +269,5 @@ def click_view_prescriptions_link(context):
 
 @then("I am taken to the correct prescription page")
 def check_url_redirect_for_prescriptions(context):
-    expected_url_pattern = re.compile(
-        r"/site/prescription-details\?prescriptionId=[\w-]+"
-    )
+    expected_url_pattern = re.compile(r"/site/prescription-details")
     context.page.wait_for_url(expected_url_pattern)

--- a/features/steps/cpts_ui/search_for_a_prescription_steps.py
+++ b/features/steps/cpts_ui/search_for_a_prescription_steps.py
@@ -130,9 +130,7 @@ def redirected_to_nhs_not_found(context):
 
 @then('I am on the prescription list current page with NHS number "{nhs_number}"')
 def redirected_to_nhs_current(context, nhs_number):
-    expected_url = re.compile(
-        rf"/site/prescription-list-current\?nhsNumber={nhs_number}"
-    )
+    expected_url = re.compile("/site/prescription-list-current")
     context.page.wait_for_url(expected_url, wait_until="load", timeout=60000)
 
 

--- a/features/steps/cpts_ui/search_for_a_prescription_steps.py
+++ b/features/steps/cpts_ui/search_for_a_prescription_steps.py
@@ -87,15 +87,6 @@ def click_search_button(context):
     page.find_prescription_button.click()
 
 
-@then('I am redirected to the prescription results page for "{prescription_id}"')
-def redirected_to_results(context, prescription_id):
-    expected_url = re.compile(
-        r"/site/prescription-list-(?:current|past|future)\?prescriptionId="
-        + prescription_id
-    )
-    context.page.wait_for_url(expected_url)
-
-
 @then("I see a prescription ID validation error is displayed")
 def i_see_prescription_id_validation_error(context):
     page = SearchForAPrescription(context.page)


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- search params are now stored in state in the UI so we need to navigate to specific pages